### PR TITLE
Remove dependency on Arduino's millis

### DIFF
--- a/examples/function-fsm-timed-example/function-fsm-timed-example.ino
+++ b/examples/function-fsm-timed-example/function-fsm-timed-example.ino
@@ -1,0 +1,44 @@
+#include <FunctionFSM.h>
+
+
+//non-class fsm.
+
+//variables
+char a = 'a';
+char b = 'b';
+
+//fsm state functions
+void a_on_enter(){
+  digitalWrite(LED_BUILTIN, LOW);
+}
+
+void b_on_enter(){
+  digitalWrite(LED_BUILTIN, HIGH);
+}
+
+//fsm states (initialise in MyClass constructor)
+FunctionState state_a(&a_on_enter, nullptr, nullptr);
+FunctionState state_b(&b_on_enter, nullptr, nullptr);
+
+//fsm (initialise with MyClass constructor)
+FunctionFsm fsm(&state_a);
+
+
+void initfsm(){
+  fsm.add_timed_transition(&state_a, &state_b, 1000, nullptr);
+  fsm.add_timed_transition(&state_b, &state_a, 500, nullptr);
+}
+
+void setup(){
+  Serial.begin(19200);
+  Serial.flush();
+  
+  pinMode(LED_BUILTIN,OUTPUT);
+  
+  //init fsm
+  initfsm();
+}
+
+void loop(){
+  fsm.run_machine();
+}

--- a/src/FunctionFSM.cpp
+++ b/src/FunctionFSM.cpp
@@ -57,7 +57,7 @@ void FunctionFsm::add_timed_transition(FunctionState* state_from,
   
   TimedTransition timed_transition;
   timed_transition.transition = transition;
-  timed_transition.start = std::chrono::high_resolution_clock::from_time_t(0);
+  timed_transition.start = std::chrono::high_resolution_clock::now();
   timed_transition.interval = interval;
   
   m_timed_transitions.push_back(timed_transition);
@@ -91,15 +91,10 @@ void FunctionFsm::trigger(int event){
 void FunctionFsm::check_timed_transitions(){
   for (auto& tt : m_timed_transitions){
     if(tt.transition.state_from == m_current_state){
-      if(tt.start == std::chrono::high_resolution_clock::from_time_t(0)){
+      std::chrono::time_point<std::chrono::high_resolution_clock> now = std::chrono::high_resolution_clock::now();
+      if (std::chrono::duration_cast<std::chrono::milliseconds>(now - tt.start).count() >= tt.interval){
+        FunctionFsm::make_transition(&(tt.transition));
         tt.start = std::chrono::high_resolution_clock::now();
-      }
-      else {
-        std::chrono::time_point<std::chrono::high_resolution_clock> now = std::chrono::high_resolution_clock::now();
-        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - tt.start).count() >= tt.interval){
-          FunctionFsm::make_transition(&(tt.transition));
-          tt.start = std::chrono::high_resolution_clock::from_time_t(0);
-        }
       }
     }
   }

--- a/src/FunctionFSM.cpp
+++ b/src/FunctionFSM.cpp
@@ -57,7 +57,7 @@ void FunctionFsm::add_timed_transition(FunctionState* state_from,
   
   TimedTransition timed_transition;
   timed_transition.transition = transition;
-  timed_transition.start = 0;
+  timed_transition.start = std::chrono::high_resolution_clock::from_time_t(0);
   timed_transition.interval = interval;
   
   m_timed_transitions.push_back(timed_transition);
@@ -91,14 +91,14 @@ void FunctionFsm::trigger(int event){
 void FunctionFsm::check_timed_transitions(){
   for (auto& tt : m_timed_transitions){
     if(tt.transition.state_from == m_current_state){
-      if(tt.start == 0){
-        tt.start = millis();
+      if(tt.start == std::chrono::high_resolution_clock::from_time_t(0)){
+        tt.start = std::chrono::high_resolution_clock::now();
       }
       else {
-        unsigned long now = millis();
-        if (now - tt.start >= tt.interval){
+        std::chrono::time_point<std::chrono::high_resolution_clock> now = std::chrono::high_resolution_clock::now();
+        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - tt.start).count() >= tt.interval){
           FunctionFsm::make_transition(&(tt.transition));
-          tt.start = 0;
+          tt.start = std::chrono::high_resolution_clock::from_time_t(0);
         }
       }
     }
@@ -138,7 +138,7 @@ void FunctionFsm::make_transition(Transition* transition) {
   m_current_state = transition->state_to;
   
   //Initialise all timed transitions from m_current_state
-  unsigned long now = millis();
+  std::chrono::time_point<std::chrono::high_resolution_clock> now =  std::chrono::high_resolution_clock::now();
   for (auto& tt : m_timed_transitions) {
     if(tt.transition.state_from == m_current_state){
       tt.start = now;

--- a/src/FunctionFSM.h
+++ b/src/FunctionFSM.h
@@ -15,16 +15,7 @@
 
 #include <functional>
 #include <vector>
-
-//include Arduino for access to millis() (a millisecond tick count)
-//(this is currently for use on an ESP32, which supports Arduino's libraries)
-//could easily remove if using stdlib's timers instead
-#if defined(ARDUINO) && ARDUINO >= 100
-  #include <Arduino.h>
-#else
-  #include <WProgram.h>
-#endif
-
+#include <chrono>
 
 struct FunctionState {
   FunctionState(std::function<void()> on_enter,
@@ -74,7 +65,7 @@ private:
   
   struct TimedTransition {
     Transition transition;
-    unsigned long start;
+	std::chrono::time_point<std::chrono::high_resolution_clock> start;
     unsigned long interval;
   };
   


### PR DESCRIPTION
Use std::chrono instead.

Allows use in **any** modern C++ environment